### PR TITLE
fixed the boto3 library version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ PyYAML==5.3b1
 pytest==7.1.2
 fabric==3.0.0
 python-dotenv
-boto3
+boto3==1.28.40
 docker
 typing_extensions<4.6.0


### PR DESCRIPTION
$ dreamtools
Traceback (most recent call last):
  File "/cephfs/home/glinskii/dream/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/cephfs/home/glinskii/dream/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/cephfs/home/glinskii/dream/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (urllib3 2.0.4 (/cephfs/home/glinskii/dream/venv/lib/python3.8/site-packages), Requirement.parse('urllib3<1.27,>=1.25.4'), {'botocore'})
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/cephfs/home/glinskii/dream/venv/bin/dreamtools", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/cephfs/home/glinskii/dream/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3252, in <module>
    def _initialize_master_working_set():
  File "/cephfs/home/glinskii/dream/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3235, in _call_aside
    f(*args, **kwargs)
  File "/cephfs/home/glinskii/dream/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3264, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/cephfs/home/glinskii/dream/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 585, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/cephfs/home/glinskii/dream/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 598, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/cephfs/home/glinskii/dream/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (urllib3 2.0.4 (/cephfs/home/glinskii/dream/venv/lib/python3.8/site-packages), Requirement.parse('urllib3<1.27,>=1.25.4'), {'botocore'})

Fixing the boto3 library version